### PR TITLE
fix(ci): check mkdocs

### DIFF
--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -8,11 +8,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      # Pillow installation requires some system packages
-      - uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: libjpeg-dev zlib1g-dev
-          version: 1.0
       - name: Check mkdocs
         uses: deargen/workflows/actions/check-mkdocs@master
         with:


### PR DESCRIPTION
check-mkdocs가 제대로 된 python environment에서 실행되고 있지 않았음.